### PR TITLE
Update links.md

### DIFF
--- a/get-involved/links.md
+++ b/get-involved/links.md
@@ -5,7 +5,7 @@
 * [Website](https://fortressdao.finance)
 * [Twitter](https://twitter.com/FortressDAO/)
 * [Medium](https://fortressdao.medium.com)
-* [Discord](https://discord.gg/fortress/)
+* [Discord](https://discord.gg/fortress)
 * [Telegram](https://t.me/FortressDAO/)
 * [Github](https://github.com/Fortress-DAO)
 * [Governance](https://snapshot.org/#/fortressdao.eth/)


### PR DESCRIPTION
Removed trailing slash from discord url, it was forwarding to discord.com w/o the invite